### PR TITLE
ci: add workflow_dispatch trigger to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,8 @@ on:
   schedule:
     # Run CodeQL analysis weekly on Sundays at 12:00 UTC
     - cron: '0 12 * * 0'
+  # Allow manually re-running the analysis from the Actions tab
+  workflow_dispatch:
 
 permissions:
   actions: read


### PR DESCRIPTION
Allows manually re-running the security analysis from the Actions tab, e.g. to refresh stale code scanning results.