### PR TITLE
ci: move CodeQL workflow to a new file to escape stuck workflow id

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,6 +18,8 @@ on:
     branches: [ "master" ]
   schedule:
     - cron: '21 13 * * 5'
+  # Allow manually re-running the analysis from the Actions tab
+  workflow_dispatch:
 
 jobs:
   analyze:
@@ -57,7 +59,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`


### PR DESCRIPTION
The old .github/workflows/codeql.yml (workflow id 180325696) is jammed by two unrecoverable queued runs (#141, #142) that GitHub cannot cancel or delete. Since a workflow's identity is its file path, recreating it at a new path gives a fresh workflow id with a clean run history.

Also adds a workflow_dispatch trigger (manual re-run button) and bumps actions/checkout v4 -> v6 (off the deprecated Node 20 runtime).