### PR TITLE
ci: set least-privilege permissions on commit validation workflow

### DIFF
--- a/.github/workflows/validate-commits.yml
+++ b/.github/workflows/validate-commits.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+# Least-privilege default: this workflow only needs to read the repository
+permissions:
+  contents: read
+
 jobs:
   validate-commits:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves the CodeQL actions/missing-workflow-permissions alert: the validate-commits workflow had no explicit permissions block, so the GITHUB_TOKEN inherited the repository default. It only reads the repo, so scope it to contents: read.