### PR TITLE
refactor: replace remaining magic numbers with named constants

### DIFF
--- a/src/components/map/DungeonBoss.tsx
+++ b/src/components/map/DungeonBoss.tsx
@@ -1,4 +1,4 @@
-import { CSS_CLASSES } from "@/constants";
+import { BOSS_STATES, CSS_CLASSES } from "@/constants";
 import { buildDungeonCaption, type DungeonItem } from "@/data/chests";
 import { useGameStore } from "@/stores/gameStore";
 import { getAssetPath, transformMapCoordinates } from "@/utils";
@@ -28,8 +28,8 @@ export const DungeonBoss = ({ dungeon, index }: DungeonBossProps) => {
     const bossKey = `boss${index}`;
     const bossValue = items[bossKey] as number;
 
-    // If boss is beaten (value 2), return "opened"
-    if (bossValue === 2) return "opened";
+    // If boss is beaten, return "opened"
+    if (bossValue === BOSS_STATES.BEATEN) return "opened";
 
     if (dungeon.isBeaten) return "opened";
     return dungeon.isBeatable(items, medallions, bigKeysVisible);

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -45,6 +45,19 @@ export const MEDALLION_VALUES = {
   UNKNOWN: 0,
 };
 
+// Glove (gauntlet) progression levels
+export const GLOVE_LEVELS = {
+  NONE: 0,
+  POWER: 1, // Power Glove
+  TITAN: 2, // Titan's Mitt
+} as const;
+
+// Boss progression states (value stored in items.bossN)
+export const BOSS_STATES = {
+  BEATEN: 2,
+  UNBEATEN: 0,
+} as const;
+
 // Small Keys Maximum Values per Dungeon
 export const SMALL_KEYS_MAX = {
   DESERT_PALACE: 1, // smallkey1

--- a/src/data/chests.ts
+++ b/src/data/chests.ts
@@ -1,3 +1,5 @@
+import { DUNGEON_INDICES, GLOVE_LEVELS, MEDALLION_VALUES } from "@/constants";
+
 // Type definitions
 
 /** Accessibility states returned by chest/dungeon availability logic. */
@@ -111,7 +113,7 @@ function steve(items: ItemState): boolean {
 
 /** True when the player has the Titan's Mitt (glove level 2). */
 function hasTitansMitt(items: ItemState): boolean {
-  return items.glove === 2;
+  return items.glove === GLOVE_LEVELS.TITAN;
 }
 
 /**
@@ -126,12 +128,15 @@ function checkMedallion(
 ): Availability | null {
   if (!items.bombos && !items.ether && !items.quake) return "unavailable";
   if (
-    (medallions[index] === 1 && !items.bombos) ||
-    (medallions[index] === 2 && !items.ether) ||
-    (medallions[index] === 3 && !items.quake)
+    (medallions[index] === MEDALLION_VALUES.BOMBOS && !items.bombos) ||
+    (medallions[index] === MEDALLION_VALUES.ETHER && !items.ether) ||
+    (medallions[index] === MEDALLION_VALUES.QUAKE && !items.quake)
   )
     return "unavailable";
-  if (medallions[index] === 0 && !(items.bombos && items.ether && items.quake))
+  if (
+    medallions[index] === MEDALLION_VALUES.UNKNOWN &&
+    !(items.bombos && items.ether && items.quake)
+  )
     return "possible";
   return null;
 }
@@ -161,8 +166,13 @@ export function buildDungeonCaption(
   index: number,
   medallions: number[],
 ): string {
-  if (index !== 8 && index !== 9) return dungeon.name;
-  return `${dungeon.name} ${icon(medallionAsset(medallions[index] ?? 0))}`;
+  if (
+    index !== DUNGEON_INDICES.MISERY_MIRE &&
+    index !== DUNGEON_INDICES.TURTLE_ROCK
+  ) {
+    return dungeon.name;
+  }
+  return `${dungeon.name} ${icon(medallionAsset(medallions[index] ?? MEDALLION_VALUES.UNKNOWN))}`;
 }
 
 // Define dungeon objects

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 import { useShallow } from "zustand/react/shallow";
-import { SMALL_KEYS_MAX_BY_INDEX } from "@/constants";
+import { DUNGEON_INDICES, SMALL_KEYS_MAX_BY_INDEX } from "@/constants";
 import {
   buildDungeonCaption,
   type ChestItem,
@@ -157,7 +157,8 @@ export const useGameStore = create<GameState>()(
           let updatedCaption = caption;
           const dungeon = dungeonsState[bossNumber];
           if (
-            (bossNumber === 8 || bossNumber === 9) &&
+            (bossNumber === DUNGEON_INDICES.MISERY_MIRE ||
+              bossNumber === DUNGEON_INDICES.TURTLE_ROCK) &&
             dungeon &&
             caption.startsWith(dungeon.name)
           ) {


### PR DESCRIPTION
- add GLOVE_LEVELS and BOSS_STATES constants
- use MEDALLION_VALUES in the medallion gate, GLOVE_LEVELS.TITAN in hasTitansMitt, DUNGEON_INDICES for Misery Mire / Turtle Rock checks (chests.ts, gameStore, DungeonBoss)