### PR TITLE
feat: show the active run settings in the preset modal

### DIFF
--- a/src/components/ui/PresetSelector.spec.tsx
+++ b/src/components/ui/PresetSelector.spec.tsx
@@ -6,7 +6,16 @@ import { useGameStore } from "@/stores/gameStore";
 vi.mock("@/stores/gameStore", () => ({ useGameStore: vi.fn() }));
 
 const applyPreset = vi.fn();
-const fakeState = { applyPreset, presetId: "open" };
+const fakeState = {
+  applyPreset,
+  presetId: "open",
+  settings: {
+    entranceShuffle: "none" as const,
+    goal: "ganon" as const,
+    keysanity: false,
+    mode: "open" as const,
+  },
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -16,26 +25,35 @@ beforeEach(() => {
 });
 
 describe("PresetSelector", () => {
+  const openList = () => {
+    fireEvent.click(screen.getByRole("button", { name: /mode/i }));
+    return screen.getByRole("dialog", { name: /choose a run type/i });
+  };
+
   it("shows the current preset name", () => {
     render(<PresetSelector />);
     expect(screen.getByText("Open")).toBeInTheDocument();
   });
 
-  it("opens the preset list when clicked", () => {
+  it("lists presets and the current run settings when opened", () => {
     render(<PresetSelector />);
-    fireEvent.click(screen.getByRole("button", { name: /mode/i }));
+    const dialog = openList();
+
     expect(
-      screen.getByRole("dialog", { name: /choose a run type/i }),
+      within(dialog).getByRole("button", { name: /^keysanity/i }),
     ).toBeInTheDocument();
-    expect(screen.getByText("Keysanity")).toBeInTheDocument();
+    // Current-run settings summary is shown
+    expect(within(dialog).getByText("Goal")).toBeInTheDocument();
+    expect(within(dialog).getByText("Defeat Ganon")).toBeInTheDocument();
   });
 
   it("asks for confirmation before switching, then applies the preset", () => {
     render(<PresetSelector />);
-    fireEvent.click(screen.getByRole("button", { name: /mode/i }));
-    fireEvent.click(screen.getByText("Keysanity"));
+    const dialog = openList();
+    fireEvent.click(
+      within(dialog).getByRole("button", { name: /^keysanity/i }),
+    );
 
-    // Confirmation dialog appears; preset not applied yet
     expect(
       screen.getByRole("dialog", { name: /switch run type/i }),
     ).toBeInTheDocument();
@@ -47,9 +65,8 @@ describe("PresetSelector", () => {
 
   it("does not switch when picking the already-active preset", () => {
     render(<PresetSelector />);
-    fireEvent.click(screen.getByRole("button", { name: /mode/i }));
-    const dialog = screen.getByRole("dialog", { name: /choose a run type/i });
-    fireEvent.click(within(dialog).getByText("Open"));
+    const dialog = openList();
+    fireEvent.click(within(dialog).getByRole("button", { name: /^open/i }));
     expect(applyPreset).not.toHaveBeenCalled();
   });
 });

--- a/src/components/ui/PresetSelector.tsx
+++ b/src/components/ui/PresetSelector.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { Modal } from "@/components/ui/Modal";
-import { getPreset, presets } from "@/data/presets";
+import { describeSettings, getPreset, presets } from "@/data/presets";
 import { useGameStore } from "@/stores/gameStore";
 
 /**
@@ -11,6 +11,7 @@ import { useGameStore } from "@/stores/gameStore";
  */
 export const PresetSelector = () => {
   const presetId = useGameStore((state) => state.presetId);
+  const settings = useGameStore((state) => state.settings);
   const applyPreset = useGameStore((state) => state.applyPreset);
 
   const [isListOpen, setIsListOpen] = useState(false);
@@ -51,6 +52,14 @@ export const PresetSelector = () => {
         onClose={() => setIsListOpen(false)}
         title="Choose a run type"
       >
+        <dl aria-label="Current run settings" className="run-settings">
+          {describeSettings(settings).map((row) => (
+            <div className="run-settings__row" key={row.label}>
+              <dt className="run-settings__label">{row.label}</dt>
+              <dd className="run-settings__value">{row.value}</dd>
+            </div>
+          ))}
+        </dl>
         <ul className="preset-list">
           {presets.map((preset) => (
             <li key={preset.id}>

--- a/src/components/ui/TrackerControls.spec.tsx
+++ b/src/components/ui/TrackerControls.spec.tsx
@@ -7,9 +7,19 @@ vi.mock("@/stores/gameStore", () => ({ useGameStore: vi.fn() }));
 
 const reset = vi.fn();
 const fakeState = {
+  // PresetSelector is rendered inside TrackerControls, so its store fields
+  // are needed too.
+  applyPreset: vi.fn(),
   exportState: vi.fn(() => "{}"),
   importState: vi.fn(() => true),
+  presetId: "open",
   reset,
+  settings: {
+    entranceShuffle: "none" as const,
+    goal: "ganon" as const,
+    keysanity: false,
+    mode: "open" as const,
+  },
 };
 
 beforeEach(() => {

--- a/src/data/presets.ts
+++ b/src/data/presets.ts
@@ -126,3 +126,38 @@ export const DEFAULT_PRESET_ID = "open";
 export const getPreset = (id: string): Preset =>
   presets.find((preset) => preset.id === id) ??
   (presets.find((preset) => preset.id === DEFAULT_PRESET_ID) as Preset);
+
+/** Human-readable labels for run settings. */
+export const MODE_LABELS: Record<RunMode, string> = {
+  inverted: "Inverted",
+  open: "Open",
+  retro: "Retro",
+  standard: "Standard",
+};
+
+export const GOAL_LABELS: Record<RunGoal, string> = {
+  "all-dungeons": "All Dungeons",
+  "fast-ganon": "Fast Ganon",
+  ganon: "Defeat Ganon",
+  pedestal: "Pedestal",
+  "triforce-hunt": "Triforce Hunt",
+};
+
+export const ENTRANCE_LABELS: Record<EntranceShuffle, string> = {
+  crossed: "Crossworld",
+  full: "Full",
+  insanity: "Insanity",
+  none: "None",
+  restricted: "Restricted",
+  simple: "Simple",
+};
+
+/** A labeled summary of a run's settings, for display. */
+export const describeSettings = (
+  settings: RunSettings,
+): { label: string; value: string }[] => [
+  { label: "Mode", value: MODE_LABELS[settings.mode] },
+  { label: "Goal", value: GOAL_LABELS[settings.goal] },
+  { label: "Keysanity", value: settings.keysanity ? "On" : "Off" },
+  { label: "Entrances", value: ENTRANCE_LABELS[settings.entranceShuffle] },
+];

--- a/src/styles/modal.css
+++ b/src/styles/modal.css
@@ -186,6 +186,40 @@
   color: var(--color-accent);
 }
 
+/* Current-run settings summary */
+.run-settings {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-xs) var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  margin: 0 0 var(--spacing-md);
+  background: var(--surface-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+}
+
+.run-settings__row {
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.run-settings__label {
+  margin: 0;
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.run-settings__value {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
 .preset-list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Presets stored mode/goal/entrance but only keysanity was visible. The Mode modal now shows a labeled summary of the current run (Mode, Goal, Keysanity, Entrances) using human-readable labels, so picking a preset is meaningful.

- add MODE_LABELS / GOAL_LABELS / ENTRANCE_LABELS and describeSettings()
- render a current-run settings panel above the preset list
- update tests to query preset cards by role to avoid label/name collisions